### PR TITLE
Flow optimizations for the DOM-centric data model approach

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+/**
+ * @flow
+ */
+
 // example of generating HTML with js
 function renderSidebar() {
   const sidebarContents = `
@@ -15,7 +19,9 @@ function renderSidebar() {
       </li>
     </ul>
   `;
-  document.querySelector('.email-list-container').innerHTML = sidebarContents;
+
+  const container = document.querySelector('.email-list-container');
+  if (container != null) container.innerHTML = sidebarContents;
 }
 
 renderSidebar();

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -12,8 +12,8 @@ import type { URLSafeBase64 } from '../utility/Base64';
 // key used to access the table is valid. It prevents you from using an
 // arbitrary string; instead you can only use a value that you’ve gotten from
 // another location in the data store.
-export opaque type MessageKey = string;
-export opaque type ThreadKey = string;
+export type MessageKey = string;
+export type ThreadKey = string;
 
 // A label can be any string, but the following have internal meanings:
 // CATEGORY_FORUMS, CATEGORY_PERSONAL, CATEGORY_SOCIAL, IMPORTANT,


### PR DESCRIPTION
#### Make ThreadKey and MessageKey not opaque
Opaque types hide their underlying structure when they are used outside the lexical scope that they were defined in. This means that arbitrary values that would otherwise be able to be coerced into that type, in this case arbitrary strings, cannot be. An opaque type validates that a module only be given a value that it itself gave the consumer: in this case, it would only be possible to key into `messages` with a key retrieved from a `Thread`.

This would be great in a virtual-DOM situation like React, where message and thread keys were bound to event handlers in the JS codebase. It breaks down when we consider binding keys to DOM elements as data attributes, or the like, as those are always retrieved as strings. Opaque types would cause more trouble than they’re worth, so I’m removing them.


#### Add flow pragma to example index.js
... and add a null check for the use of possibly undefined variable that was immediately pointed out.