### PR TITLE
Displays email subject, sender, timestamp, and snippet.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,23 +2,47 @@
  * @flow
  */
 
-// example of generating HTML with js
+import store, {
+  getMessageSubject,
+  getMessageSender,
+  getMessageTimestamp,
+  getMessageSnippet,
+} from './store';
+
+function getThreadIds() {
+  let threadIds;
+  if (store.mailboxes.INBOX) {
+    threadIds = store.mailboxes.INBOX.threadIds;
+  } else {
+    threadIds = [];
+  }
+  return threadIds;
+}
+
 function renderSidebar() {
   const sidebarContents = `
     <h2 class="email-header">Inbox</h2>
-    <ul class="email-list">
-      <li>
-        <button class="email-item" type="button">
-          <div class="sender-details">
-            <p>Email sender</p>
-            <span>Timestamp</span>
-          </div>
-          <p class="email-subject">Email1 subject</p>
-          <p>Email snippet</p>
-        </button>
-      </li>
-    </ul>
-  `;
+    <ul class="email-list">${getThreadIds()
+    .map((threadId) => {
+      const message =
+          store.threads[threadId].messages[
+            store.threads[threadId].messages.length - 1
+          ];
+      return `<li>
+            <button class="email-item" type="button">
+              <div class="sender-details">
+                <p>${getMessageSender(store.messages[message.id]) || ''}</p>
+                <span>${getMessageTimestamp(store.messages[message.id]) ||
+                  ''}</span>
+              </div>
+              <p class="email-subject">
+                ${getMessageSubject(store.messages[message.id]) || ''}</p>
+              <p>${getMessageSnippet(message)}</p>
+            </button>
+          </li>`;
+    })
+    .join('')}</ul>
+    `;
 
   const container = document.querySelector('.email-list-container');
   if (container != null) container.innerHTML = sidebarContents;

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,8 @@ function renderSidebar() {
       return `<li>
             <button class="email-item" type="button">
               <div class="sender-details">
-                <p>${getMessageSender(message) || ''}</p>
-                <span>${getMessageTimestamp(message) || ''}</span>
+                <p>${getMessageSender(message).split('\\')[0] || ''}</p>
+                <span>${getMessageTimestamp(message).split('+')[0] || ''}</span>
               </div>
               <p class="email-subject">
                 ${getMessageSubject(message) || ''}</p>

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import store, {
   getMessageSender,
   getMessageTimestamp,
   getMessageSnippet,
+  formatSender,
+  formatTime,
 } from './store';
 
 function getThreadIds() {
@@ -31,8 +33,8 @@ function renderSidebar() {
       return `<li>
             <button class="email-item" type="button">
               <div class="sender-details">
-                <p>${getMessageSender(message).split('\\')[0] || ''}</p>
-                <span>${getMessageTimestamp(message).split('+')[0] || ''}</span>
+                <p>${formatSender(getMessageSender(message)) || ''}</p>
+                <span>${formatTime(getMessageTimestamp(message)) || ''}</span>
               </div>
               <p class="email-subject">
                 ${getMessageSubject(message) || ''}</p>

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,9 @@ import store, {
 
 function getThreadIds() {
   let threadIds;
-  if (store.mailboxes.INBOX) {
-    threadIds = store.mailboxes.INBOX.threadIds;
+  const { INBOX } = store.mailboxes;
+  if (INBOX) {
+    threadIds = INBOX.threadIds;
   } else {
     threadIds = [];
   }
@@ -24,20 +25,18 @@ function renderSidebar() {
     <h2 class="email-header">Inbox</h2>
     <ul class="email-list">${getThreadIds()
     .map((threadId) => {
-      const message =
-          store.threads[threadId].messages[
-            store.threads[threadId].messages.length - 1
-          ];
+      const { messages } = store.threads[threadId];
+      const messageMetadata = messages[messages.length - 1];
+      const message = store.messages[messageMetadata.id];
       return `<li>
             <button class="email-item" type="button">
               <div class="sender-details">
-                <p>${getMessageSender(store.messages[message.id]) || ''}</p>
-                <span>${getMessageTimestamp(store.messages[message.id]) ||
-                  ''}</span>
+                <p>${getMessageSender(message) || ''}</p>
+                <span>${getMessageTimestamp(message) || ''}</span>
               </div>
               <p class="email-subject">
-                ${getMessageSubject(store.messages[message.id]) || ''}</p>
-              <p>${getMessageSnippet(message)}</p>
+                ${getMessageSubject(message) || ''}</p>
+              <p>${getMessageSnippet(messageMetadata)}</p>
             </button>
           </li>`;
     })

--- a/src/index.js
+++ b/src/index.js
@@ -33,11 +33,13 @@ function renderSidebar() {
       return `<li>
             <button class="email-item" type="button">
               <div class="sender-details">
-                <p>${formatSender(getMessageSender(message)) || ''}</p>
-                <span>${formatTime(getMessageTimestamp(message)) || ''}</span>
+                <p>${formatSender(getMessageSender(message)) ||
+                  'Unknown Sender'}</p>
+                <span>${formatTime(getMessageTimestamp(message)) ||
+                  'Unknown Date'}</span>
               </div>
               <p class="email-subject">
-                ${getMessageSubject(message) || ''}</p>
+                ${getMessageSubject(message) || 'No Subject'}</p>
               <p>${getMessageSnippet(messageMetadata)}</p>
             </button>
           </li>`;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -36,7 +36,7 @@ export function getMessageTimestamp(message: Message): ?string {
   return emailTimestamp && emailTimestamp.value;
 }
 
-export function getMessageSnippet(messagedata: MessageMetadata): ?string {
+export function getMessageSnippet(messagedata: MessageMetadata): string {
   const emailSnippet = messagedata.snippet;
   return emailSnippet;
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -41,4 +41,14 @@ export function getMessageSnippet(messageMetadata: MessageMetadata): string {
   return emailSnippet;
 }
 
+export function formatSender(messageSender: string): string {
+  const formattedSender = messageSender.split('\\')[0];
+  return formattedSender;
+}
+
+export function formatTime(messageTimestamp: string): string {
+  const formattedTime = messageTimestamp.split('+')[0];
+  return formattedTime;
+}
+
 export default store;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,16 +2,18 @@
  * The data store is currently a JSON file, but its schema mirrors the Gmail
  * API so we can feed it from your own inbox at a later date.
  *
+ * This file stores the helper functions
+ *
  * @flow
  */
 
-import type { Data, Message } from './types';
+import type { Data, Message, MessageMetadata } from './types';
 
 const store: Data = require('./emails.json');
 
 /**
  * You might find it useful to implement some functions that make accessing
- * deeply nested attributes of Messages or Threads...
+ * deeply nested attributes of Messages or Threads easier...
  */
 
 // For example, this returns the subject of a given message if it is defined
@@ -20,6 +22,23 @@ export function getMessageSubject(message: Message): ?string {
   const { headers } = message.payload;
   const subjectHeader = headers.find(header => header.name === 'Subject');
   return subjectHeader && subjectHeader.value;
+}
+
+export function getMessageSender(message: Message): ?string {
+  const { headers } = message.payload;
+  const emailSender = headers.find(header => header.name === 'From');
+  return emailSender && emailSender.value;
+}
+
+export function getMessageTimestamp(message: Message): ?string {
+  const { headers } = message.payload;
+  const emailTimestamp = headers.find(header => header.name === 'Date');
+  return emailTimestamp && emailTimestamp.value;
+}
+
+export function getMessageSnippet(messagedata: MessageMetadata): ?string {
+  const emailSnippet = messagedata.snippet;
+  return emailSnippet;
 }
 
 export default store;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -36,8 +36,8 @@ export function getMessageTimestamp(message: Message): ?string {
   return emailTimestamp && emailTimestamp.value;
 }
 
-export function getMessageSnippet(messagedata: MessageMetadata): string {
-  const emailSnippet = messagedata.snippet;
+export function getMessageSnippet(messageMetadata: MessageMetadata): string {
+  const emailSnippet = messageMetadata.snippet;
   return emailSnippet;
 }
 


### PR DESCRIPTION
This pull request renders one `<li>` for each thread in the `INBOX` mailbox. The sender, timestamp, subject, and snippet from the last (most recent) email in each thread are being displayed.

<img width="971" alt="screen shot 2018-01-24 at 7 06 38 pm" src="https://user-images.githubusercontent.com/19351087/35363823-08cd9f92-013a-11e8-9b19-9daedf13acab.png">
